### PR TITLE
add loopback range to default private masks

### DIFF
--- a/xff.go
+++ b/xff.go
@@ -10,6 +10,7 @@ import (
 
 // list of private subnets
 var privateMasks, _ = toMasks([]string{
+	"127.0.0.0/8",
 	"10.0.0.0/8",
 	"172.16.0.0/12",
 	"192.168.0.0/16",


### PR DESCRIPTION
Suggesting to add 127/8 to the default private masks range, it doesn't seem like things get much more private than the loopback. 
Per [RFC5735](https://tools.ietf.org/html/rfc5735) the whole of 127/8 is designated private:

>    127.0.0.0/8 - This block is assigned for use as the Internet host
>   loopback address.  A datagram sent by a higher-level protocol to an
>   address anywhere within this block loops back inside the host.  This
>   is ordinarily implemented using only 127.0.0.1/32 for loopback.  As
>   described in [RFC1122], Section 3.2.1.3, addresses within the entire
>   127.0.0.0/8 block do not legitimately appear on any network anywhere.
