### PR TITLE
Properly parse nested proxy

### DIFF
--- a/xff.go
+++ b/xff.go
@@ -56,7 +56,7 @@ func Parse(ipList string, allowed func(sip string) bool) string {
 		ip := ipSplit[i]
 		ip = strings.TrimSpace(ip)
 		parsedIP := net.ParseIP(ip)
-		if parsedIP != nil && IsPublicIP(parsedIP) {
+		if parsedIP != nil {
 			lastValidIP = parsedIP
 			if !allowed(ip) {
 				break

--- a/xff_test.go
+++ b/xff_test.go
@@ -19,7 +19,7 @@ func TestParse_none(t *testing.T) {
 
 func TestParse_localhost(t *testing.T) {
 	res := Parse("127.0.0.1", allowAll)
-	assert.Equal(t, "", res)
+	assert.Equal(t, "127.0.0.1", res)
 }
 
 func TestParse_invalid(t *testing.T) {
@@ -49,7 +49,7 @@ func TestParse_multi_first(t *testing.T) {
 
 func TestParse_multi_last(t *testing.T) {
 	res := Parse("192.168.110.162, 190.57.149.90", allowAll)
-	assert.Equal(t, "190.57.149.90", res)
+	assert.Equal(t, "192.168.110.162", res)
 }
 
 func TestParse_multi_accept(t *testing.T) {
@@ -57,6 +57,18 @@ func TestParse_multi_accept(t *testing.T) {
 		return ip == "1.0.0.3"
 	})
 	assert.Equal(t, "1.0.0.2", res)
+}
+
+func TestParse_multi_accept_intermediate_private(t *testing.T) {
+	res := Parse("1.0.0.1, 1.0.0.2, 10.0.0.1, 1.0.0.3", func(ip string) bool {
+		return ip == "1.0.0.3" || ip == "10.0.0.1"
+	})
+	assert.Equal(t, "1.0.0.2", res)
+}
+
+func TestParse_multi_accept_final_private(t *testing.T) {
+	res := Parse("10.0.0.1, 1.0.0.3", allowAll)
+	assert.Equal(t, "10.0.0.1", res)
 }
 
 func TestParse_multi_with_invalid(t *testing.T) {

--- a/xff_test.go
+++ b/xff_test.go
@@ -8,63 +8,74 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func allowAll(string) bool {
+	return true
+}
+
 func TestParse_none(t *testing.T) {
-	res := Parse("")
+	res := Parse("", allowAll)
 	assert.Equal(t, "", res)
 }
 
 func TestParse_localhost(t *testing.T) {
-	res := Parse("127.0.0.1")
+	res := Parse("127.0.0.1", allowAll)
 	assert.Equal(t, "", res)
 }
 
 func TestParse_invalid(t *testing.T) {
-	res := Parse("invalid")
+	res := Parse("invalid", allowAll)
 	assert.Equal(t, "", res)
 }
 
 func TestParse_invalid_sioux(t *testing.T) {
-	res := Parse("123#1#2#3")
+	res := Parse("123#1#2#3", allowAll)
 	assert.Equal(t, "", res)
 }
 
 func TestParse_invalid_private_lookalike(t *testing.T) {
-	res := Parse("102.3.2.1")
+	res := Parse("102.3.2.1", allowAll)
 	assert.Equal(t, "102.3.2.1", res)
 }
 
 func TestParse_valid(t *testing.T) {
-	res := Parse("68.45.152.220")
+	res := Parse("68.45.152.220", allowAll)
 	assert.Equal(t, "68.45.152.220", res)
 }
 
 func TestParse_multi_first(t *testing.T) {
-	res := Parse("12.13.14.15, 68.45.152.220")
+	res := Parse("12.13.14.15, 68.45.152.220", allowAll)
 	assert.Equal(t, "12.13.14.15", res)
 }
 
 func TestParse_multi_last(t *testing.T) {
-	res := Parse("192.168.110.162, 190.57.149.90")
+	res := Parse("192.168.110.162, 190.57.149.90", allowAll)
 	assert.Equal(t, "190.57.149.90", res)
 }
 
+func TestParse_multi_accept(t *testing.T) {
+	res := Parse("1.0.0.1, 1.0.0.2, 1.0.0.3", func(ip string) bool {
+		return ip == "1.0.0.3"
+	})
+	assert.Equal(t, "1.0.0.2", res)
+}
+
 func TestParse_multi_with_invalid(t *testing.T) {
-	res := Parse("192.168.110.162, invalid, 190.57.149.90")
+	res := Parse("192.168.110.162, invalid, 190.57.149.90", allowAll)
 	assert.Equal(t, "190.57.149.90", res)
 }
 
 func TestParse_multi_with_invalid2(t *testing.T) {
-	res := Parse("192.168.110.162, 190.57.149.90, invalid")
-	assert.Equal(t, "190.57.149.90", res)
+	res := Parse("192.168.110.162, 190.57.149.90, invalid", allowAll)
+	assert.Equal(t, "", res)
 }
 
 func TestParse_multi_with_invalid_sioux(t *testing.T) {
-	res := Parse("192.168.110.162, 190.57.149.90, 123#1#2#3")
-	assert.Equal(t, "190.57.149.90", res)
+	res := Parse("192.168.110.162, 190.57.149.90, 123#1#2#3", allowAll)
+	assert.Equal(t, "", res)
 }
 
 func TestParse_ipv6_with_port(t *testing.T) {
-	res := Parse("2604:2000:71a9:bf00:f178:a500:9a2d:670d")
+	res := Parse("2604:2000:71a9:bf00:f178:a500:9a2d:670d", allowAll)
 	assert.Equal(t, "2604:2000:71a9:bf00:f178:a500:9a2d:670d", res)
 }
 
@@ -104,6 +115,32 @@ func TestGetRemoteAddr_ipv6_with_xff(t *testing.T) {
 	}
 	ra := GetRemoteAddr(r)
 	assert.Equal(t, "[2001:db8:0:1:1:1:1:1]:1234", ra)
+}
+
+func TestGetRemoteAddrIfAllowed_ipv4_with_xff(t *testing.T) {
+	r := &http.Request{
+		RemoteAddr: "1.2.3.4:1234",
+		Header: http.Header{
+			"X-Forwarded-For": []string{"100.1.0.1, 100.0.0.1"},
+		},
+	}
+	ra := GetRemoteAddrIfAllowed(r, func(ip string) bool {
+		return ip == "1.2.3.4" || ip == "100.0.0.1"
+	})
+	assert.Equal(t, "100.1.0.1:1234", ra)
+}
+
+func TestGetRemoteAddrIfAllowed_ipv6_with_xff(t *testing.T) {
+	r := &http.Request{
+		RemoteAddr: "1.2.3.4:1234",
+		Header: http.Header{
+			"X-Forwarded-For": []string{"2001:db8:cafe::17, 2001:db8:0:1:1:1:1:1"},
+		},
+	}
+	ra := GetRemoteAddrIfAllowed(r, func(ip string) bool {
+		return ip == "1.2.3.4" || ip == "2001:db8:0:1:1:1:1:1"
+	})
+	assert.Equal(t, "[2001:db8:cafe::17]:1234", ra)
 }
 
 func TestToMasks_empty(t *testing.T) {


### PR DESCRIPTION
Closes #6 

Only continue parsing IP backwards if the proxy is in allowed IP range.

This PR breaks the public interface by introducing `allowed` function parameter into Parse. Also the Parse behavior is now changed:

- If invalid address are found, the last valid IP are returned instead of silently skipping those invalid address.
- Local IP address can now be returned (`IsPublicIP` become unused function) as all local proxy IP should be listed in AllowedSubnets.

I believe this breaking change is justified as it prevents people from having security issues by not providing insecure validation mechanism. It should be released as versioned package though (eg. using gopkg.in)