### PR TITLE
Fix link to XFF RFC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # X-Forwarded-For middleware fo Go [![godoc](http://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/github.com/sebest/xff) [![Build Status](https://travis-ci.org/sebest/xff.svg?branch=master)](https://travis-ci.org/sebest/xff)
 
-Package `xff` is a `net/http` middleware/handler to parse [Forwarded HTTP Extension](http://tools.ietf.org/html/rfc7239) in Golang.
+Package `xff` is a `net/http` middleware/handler to parse [Forwarded HTTP Extension](https://datatracker.ietf.org/doc/html/rfc7239) in Golang.
 
 ## Example usage
 


### PR DESCRIPTION
The current link to the XFF RFC returns a 404 Not Found error. This change updates the link to use the new location for the RFC.